### PR TITLE
reverted 'numeric checks check'

### DIFF
--- a/src/pandabear/model.py
+++ b/src/pandabear/model.py
@@ -236,19 +236,6 @@ class DataFrameModel(BaseModel):
                     f"Regex is used for `{name}` in schema `{cls.__name__}`, but no alias is defined."
                 )
 
-            # Check that number checks are not used on non-numeric columns
-            if any(
-                [
-                    field.ge is not None,
-                    field.gt is not None,
-                    field.le is not None,
-                    field.lt is not None,
-                ]
-            ) and typ not in [int, float]:
-                raise SchemaDefinitionError(
-                    f"Numerical check is used for `{name}` in schema `{cls.__name__}`, but the field is not numeric."
-                )
-
             # Check that string checks arenot used on non-string columns
             if any(
                 [


### PR DESCRIPTION
Didn't see this in my veryveryquick review: the less and greater checks are perfectly valid for non-numeric types, as long as they have the corresponding dunder-methods implemented. (In particular, it is useful for strings.)

I'm leaving check-for-strings-checks which ofc makes sense... but wouldn't the failure of the check itself be sufficient? If we try, pandas raises the following:
```
AttributeError: Can only use .str accessor with string values!
```

