### PR TITLE
Draft of general type checking

### DIFF
--- a/src/pandabear/model.py
+++ b/src/pandabear/model.py
@@ -5,6 +5,7 @@ from typing import Any, Union
 import numpy as np
 import pandas as pd
 
+from pandabear import type_checking
 from pandabear.column_checks import CHECK_NAME_FUNCTION_MAP
 from pandabear.exceptions import (
     CoersionError,
@@ -57,16 +58,16 @@ class BaseModel:
         Returns:
             pd.Series: The validated series.
         """
-        dtype = TYPE_DTYPE_MAP.get(typ, typ)
+        #  dtype = TYPE_DTYPE_MAP.get(typ, typ)
 
-        if se.dtype != dtype:
+        if not type_checking.is_of_type(se, typ):
             if coerce:
                 try:
                     se = se.astype(typ)
                 except ValueError:
-                    raise CoersionError(f"Could not coerce `{se.name}` with dtype {se.dtype} to {dtype}")
+                    raise CoersionError(f"Could not coerce `{se.name}` with dtype {se.dtype} to {typ}")
             else:
-                raise SchemaValidationError(f"Expected `{se.name}` with dtype {dtype} but found {se.dtype}")
+                raise SchemaValidationError(f"Expected `{se.name}` with dtype {typ} but found {se.dtype}")
 
         for check_name, check_func in CHECK_NAME_FUNCTION_MAP.items():
             check_value = getattr(field, check_name)

--- a/src/pandabear/type_checking.py
+++ b/src/pandabear/type_checking.py
@@ -47,3 +47,4 @@ def is_of_type(series_or_index, typ):
         return TYPE_CHECK_MAP[typ](series_or_index, typ)
     if isinstance(typ, type(pd.CategoricalDtype())):
         return check_dtype_equality(series_or_index, typ)
+    check_dtype_equality(series_or_index, typ)

--- a/src/pandabear/type_checking.py
+++ b/src/pandabear/type_checking.py
@@ -1,0 +1,49 @@
+import datetime
+
+import numpy as np
+import pandas as pd
+
+
+def check_dtype_equality(series_or_index, typ):
+    return series_or_index.dtype == typ
+
+
+def check_isinstance(series_or_index, typ):
+    return isinstance(series_or_index, typ)
+
+
+def check_str_object(series_or_index, typ):
+    return check_dtype_equality(series_or_index, np.dtype("O"))
+
+
+def check_datetime64(series_or_index, typ):
+    return check_dtype_equality(series_or_index, np.dtype("datetime64[ns]"))
+
+
+def check_str_expensive(series_or_index, typ):
+    if not check_str_object(series_or_index, None):
+        return False
+    return all(isinstance(x, str) for x in series_or_index)
+
+
+def check_bare_categorical_dtype(series_or_index, typ):
+    return check_dtype_equality(series_or_index, "category")
+
+
+TYPE_CHECK_MAP = {
+    int: check_dtype_equality,
+    float: check_dtype_equality,
+    bool: check_dtype_equality,
+    str: check_str_object,
+    np.datetime64: check_datetime64,
+    datetime.datetime: check_datetime64,
+    pd.CategoricalDtype: check_bare_categorical_dtype,
+    pd.DatetimeIndex: check_isinstance,
+}
+
+
+def is_of_type(series_or_index, typ):
+    if typ in TYPE_CHECK_MAP:
+        return TYPE_CHECK_MAP[typ](series_or_index, typ)
+    if isinstance(typ, type(pd.CategoricalDtype())):
+        return check_dtype_equality(series_or_index, typ)

--- a/tests/test_type_checking.py
+++ b/tests/test_type_checking.py
@@ -1,0 +1,38 @@
+import datetime
+
+import numpy as np
+import pandas as pd
+
+from pandabear import type_checking
+
+
+def test_datetime():
+    series = pd.date_range("2020-01-01", "2020-01-03")
+    assert type_checking.is_of_type(series, datetime.datetime)
+    assert type_checking.is_of_type(series, np.datetime64)
+
+
+def test_check_datetime_index():
+    index = pd.DatetimeIndex(["2020-01-01", "2020-01-03"])
+    assert type_checking.is_of_type(index, pd.DatetimeIndex)
+
+
+def test_bare_categorical_dtype():
+    series = pd.Series(["a", "b", "c"], dtype="category")
+    assert type_checking.is_of_type(series, pd.CategoricalDtype)
+
+
+def test_categorical_dtype():
+    cat_type_ordered = pd.CategoricalDtype(["a", "b"], ordered=True)
+    cat_series = pd.CategoricalIndex(list("aaabbbabba"), categories=["a", "b"], ordered=True).to_series()
+    assert type_checking.is_of_type(cat_series, cat_type_ordered)
+
+    cat_type_unordered = pd.CategoricalDtype(["a", "b"], ordered=False)
+    assert not type_checking.is_of_type(cat_series, cat_type_unordered)
+
+
+if __name__ == "__main__":
+    test_datetime()
+    test_check_datetime_index()
+    test_bare_categorical_dtype()
+    test_categorical_dtype()


### PR DESCRIPTION
I think the following structure makes sense, and that it allows for some speed

1. where we can, define the mapping between types and checks:
   - This can be extended with a full list of e.g. all numpy types that works with the simple dtype check.
   - also works for SOME classes (eg. the different non-parameterised versions of index types)
   
2. If not possible to define a key, as for the categorical Dtype with categories and order defined, add an if in the `check_types` function.
   - This approach should work for other parameterized dtypes.

3. I haven't added the check-all-or-a-sample-of-elements-for-type-by-iteration.

If you agree with the approach, I'll add typehints and more types.